### PR TITLE
Check Arrayness before processing array items

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -285,6 +285,10 @@ function validateValue(key, field, value, models) {
             }
         }
 
+        if(field.validatedType === "byte") {
+            // It is not clear what a 'byte' is
+        }
+
         if (field.enum) {
             var err = validateEnums(key, value, field.enum);
             if (err) errors.push(err);
@@ -308,11 +312,15 @@ function validateType(name, property, field, models) {
     }
 
     if(expectedType === 'array') {
+        if(!Array.isArray(property)) {
+            return new Error(name + ' is not an array. An array is expected.');
+        }
+
         if(field.items && field.items.type) {
             // These items are a baser type and not a referenced model
             var fieldType = field.items.type;
             var count = 0;
-            var arrayErrors = []
+            var arrayErrors = [];
             property.forEach(function (value) {
                 var errors =  validateValue(name + count.toString(), field.items, value, models)
                 if(errors) {
@@ -346,7 +354,6 @@ function validateType(name, property, field, models) {
                 }
             }
         }
-        // We can't do arrays yet but we need to make sure that they do not fail.
         return null;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "swagger-model-validator",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Validate incoming objects against Swagger Models.",
     "keywords": [ "Swagger", "Validation" ],
     "licence": "MIT",

--- a/tests/testArrayValidation.js
+++ b/tests/testArrayValidation.js
@@ -153,5 +153,29 @@ module.exports.validationTests = {
         test.ok(!errors.valid);
 
         test.done();
+    },
+    arrayTypeIsNotArrayRequired: function(test) {
+        var data = {
+            sample: "Test;Hello;Factor"
+        };
+        var model = {
+            required: [ 'sample' ],
+            properties: {
+                sample: {
+                    type: 'array',
+                    items: {
+                        type: "string"
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === "sample is not an array. An array is expected.", errors.errors[0].message);
+
+        test.done();
     }
 };


### PR DESCRIPTION
Fix #28 to prevent an unhelpfull error if a non-array is passed in when an array is expected.