### PR TITLE
Resolve #30 - Add support to disallow targets with extra properties

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -13,7 +13,7 @@ function Validator(swagger) {
 
     this.swagger = swagger;
     if(swagger) {
-        swagger.validateModel = function(modelName, obj, allowBlankTarget) {
+        swagger.validateModel = function(modelName, obj, allowBlankTarget, disallowExtraProperties) {
             // this is now going to run in the scope of swagger...
             var model = modelName;
             if(isStringType(modelName))
@@ -21,13 +21,13 @@ function Validator(swagger) {
                 model = this.allModels[modelName];
             }
 
-            return validate(obj, model, this.allModels, allowBlankTarget, self.customValidators);
+            return validate(obj, model, this.allModels, allowBlankTarget, disallowExtraProperties, self.customValidators);
         };
     }
 }
 
-Validator.prototype.validate = function(target, swaggerModel, swaggerModels, allowBlankTarget) {
-    return validate(target, swaggerModel, swaggerModels, allowBlankTarget, this.customValidators);
+Validator.prototype.validate = function(target, swaggerModel, swaggerModels, allowBlankTarget, disallowExtraProperties) {
+    return validate(target, swaggerModel, swaggerModels, allowBlankTarget, disallowExtraProperties, this.customValidators);
 };
 
 Validator.prototype.addFieldValidator = function(modelName, fieldName, validatorFunction){
@@ -88,7 +88,7 @@ function getCustomValidators(modelName, fieldName, validators) {
     return null;
 }
 
-function validate(target, swaggerModel, swaggerModels, allowBlankTargets, customValidators) {
+function validate(target, swaggerModel, swaggerModels, allowBlankTargets, disallowExtraProperties, customValidators) {
     if(swaggerModels === true && allowBlankTargets === undefined) {
         allowBlankTargets = true;
         swaggerModels = undefined;
@@ -118,7 +118,7 @@ function validate(target, swaggerModel, swaggerModels, allowBlankTargets, custom
         }
     }
 
-    var validationErrs = validateSpec(target, swaggerModel, swaggerModels, customValidators);
+    var validationErrs = validateSpec(target, swaggerModel, swaggerModels, disallowExtraProperties, customValidators);
 
     if (validationErrs) {
         return createReturnObject(validationErrs, swaggerModel.id);
@@ -176,11 +176,30 @@ function createReturnObject(errors, modelName) {
     return result;
 }
 
-function validateSpec(target, model, models, customValidators) {
+function validateProperties(targetProperties, modelProperties) {
+    var errors = [];
+
+    if(targetProperties) {
+        for (key in targetProperties) {
+            if (!modelProperties[key]) {
+                errors.push(new Error("Target property '" + key + "' is not in the model"));
+            }
+        }
+    }
+
+    return errors.length > 0 ? errors : null;
+}
+
+function validateSpec(target, model, models, disallowExtraProperties, customValidators) {
     var properties = model.properties;
     var errors = [];
+
     if(!properties) {
         return null;
+    }
+
+    if(disallowExtraProperties) {
+        errors = validateProperties(Object.keys(target), properties) || [];
     }
 
     for(key in properties) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "swagger-model-validator",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "description": "Validate incoming objects against Swagger Models.",
     "keywords": [ "Swagger", "Validation" ],
     "licence": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ var validator = new Validator(swagger);
 Now you can call validateModel on swagger to validate an incoming json object.
 
 ```
-var validation = swagger.validateModel("modelName", jsonObject);
+var validation = swagger.validateModel("modelName", jsonObject, _allowBlankTarget_, _disallowExtraProperties_);
 ```
 
 This returns a validation results object
@@ -79,7 +79,7 @@ or if validation fails
 You can also call the validation directly
 
 ```
-var validation = validator.validate(object, swaggerModel, swaggerModels);
+var validation = validator.validate(object, swaggerModel, swaggerModels, allowBlankTarget, disallowExtraProperties);
 ```
 
 will return the same validation results but requires the actual swagger model and not its name.  _The swaggerModels
@@ -95,6 +95,16 @@ var validation = swagger.validateModel("modelName", target, true);
 
 This will allow an empty object `{ }` to be validated without errors. We consider a blank object to be worthless in most
 cases and so should normally fail, but there is always the chance that it might not be worthless so we've added the bypass.
+
+### Preventing extra properties
+From 1.2 an optional parameter can be passed into the validation request to control if extra properties should be disallowed.
+If this flag is true then the target object cannot contain any properties that are not defined on the model.
+If it is blank or false then the target object __can__ include extra properties (this is the default behaviour and the same
+as pre 1.2)
+
+```
+var validation = swagger.validateModel("modelName", target, true, true);
+```
 
 ##Custom Field Validators
 You can add a custom field validator for a model to the validator from version 1.0.3 onwards.  This allows you to add a

--- a/tests/extraPropertiesTests.js
+++ b/tests/extraPropertiesTests.js
@@ -1,0 +1,52 @@
+/**
+ * Created by bdunn on 19/03/2015.
+ */
+var Validator = require('../lib/modelValidator');
+var validator = new Validator();
+
+module.exports.validatorTests = {
+    allowExtraProperties: function (test) {
+        var data = {
+            id: 1,
+            count: 4
+        };
+        var model = {
+            required: [ 'id' ],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(1);
+        test.ok(errors.valid);
+
+        test.done();
+    },
+    disallowExtraProperties: function (test) {
+        var data = {
+            id: 1,
+            count: 4
+        };
+        var model = {
+            required: [ 'id' ],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model, null, false, true);
+
+        test.expect(1);
+        test.ok(!errors.valid);
+
+        test.done();
+    }
+};


### PR DESCRIPTION
Handle validating that the validating object does not have any extra properties (i.e. Properties that are not defined on the Swagger Model being validated against)