### PR TITLE
Allow arbitrary string formats

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -428,6 +428,7 @@ function isStringType(property, format) {
                 return true;
             }
         }
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
According to the swagger-2.0 spec, formats may be used even though they are
not defined by the specification. This commit changes validation to pass
if formats are not one of the predefined types.

https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#dataTypeFormat