### PR TITLE
Swagger 2 improvements

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -383,7 +383,7 @@ function validateType(name, property, field, models) {
         format = format.toLowerCase();
     }
 
-    if(property === undefined) {
+    if(property === undefined || property === null) {
         return null;
     }
 
@@ -564,7 +564,7 @@ function validateRequiredFields(object, fields) {
     for (var i = 0; i < fields.length; ++i) {
         var property = fields[i];
         try {
-            if(!object.hasOwnProperty(property) || object[property] === "") {
+            if(!object.hasOwnProperty(property) || object[property] === "" || object[property] === null) {
                 errors.push(new Error(property + ' is a required field'));
             }
         } catch (e) {
@@ -577,6 +577,9 @@ function validateRequiredFields(object, fields) {
 }
 
 function validateEnums(name, value, enums) {
+    if (value === undefined || value === null) {
+        return null;
+    }
     for(var index in enums) {
         if(value === enums[index]) {
             return null;

--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -18,10 +18,10 @@ function Validator(swagger) {
             var model = modelName;
             if(isStringType(modelName))
             {
-                model = this.allModels[modelName];
+                model = this.definitions[modelName];
             }
 
-            return validate(obj, model, this.allModels, allowBlankTarget, disallowExtraProperties, self.customValidators);
+            return validate(obj, model, this.definitions, allowBlankTarget, disallowExtraProperties, self.customValidators);
         };
     }
 }
@@ -356,7 +356,8 @@ function validateType(name, property, field, models) {
             }
         } else if(models && field.items && field.items.$ref) {
             // These items are a referenced model
-            var model = models[field.items.$ref];
+            var fieldRef = field.items.$ref.replace('#/definitions/', '');
+            var model = models[fieldRef];
             if(model) {
                 var count = 0;
                 var arrayErrors = [];

--- a/tests/testRefModels.js
+++ b/tests/testRefModels.js
@@ -101,6 +101,56 @@ module.exports.refTests = {
         test.ok(errors.valid);
         test.done();
     },
+    hasRefWithinArray: function(test) {
+        var data = {
+            sample: true,
+            location: [{
+                right: 1,
+                bottom: 1
+            }]
+        };
+
+        var models = {
+            dataModel: {
+                required: [ "sample" ],
+                properties: {
+                    sample: {
+                        type: "boolean"
+                    },
+                    location: {
+                        type: "array",
+                        items: {
+                            $ref: "#/definitions/Location"
+                        }
+                    }
+                }
+            },
+            Location: {
+                required: [ "top", "left" ],
+                properties: {
+                    top: {
+                        type: "integer"
+                    },
+                    left: {
+                        type: "integer"
+                    },
+                    right: {
+                        type: "integer"
+                    },
+                    bottom: {
+                        type: "integer"
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(data, models["dataModel"], models);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errorCount === 2, "Errors: " + errors.errors);
+        test.done();
+    },
     hasRefWithMissingDataTest: function(test) {
         var data = {
             sample: true,


### PR DESCRIPTION
* Models inside of swagger 2.0 spec have been renamed to definitions.

* Items referenced in an array also need to receive the definition stripping
treatment.

* Null should not be a value to validate against and should not count as existing.