### PR TITLE
Validate use of $refs for a primitive value.

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -35,13 +35,13 @@ function Validator(swagger) {
                 model = models[subModelName];
             }
 
-            return validate(obj, model, models, allowBlankTarget, disallowExtraProperties, self.customValidators);
+            return validate(modelName, obj, model, models, allowBlankTarget, disallowExtraProperties, self.customValidators);
         };
     }
 }
 
 Validator.prototype.validate = function(target, swaggerModel, swaggerModels, allowBlankTarget, disallowExtraProperties) {
-    return validate(target, swaggerModel, swaggerModels, allowBlankTarget, disallowExtraProperties, this.customValidators);
+    return validate('rootModel', target, swaggerModel, swaggerModels, allowBlankTarget, disallowExtraProperties, this.customValidators);
 };
 
 Validator.prototype.addFieldValidator = function(modelName, fieldName, validatorFunction){
@@ -102,7 +102,7 @@ function getCustomValidators(modelName, fieldName, validators) {
     return null;
 }
 
-function validate(target, swaggerModel, swaggerModels, allowBlankTargets, disallowExtraProperties, customValidators) {
+function validate(name, target, swaggerModel, swaggerModels, allowBlankTargets, disallowExtraProperties, customValidators) {
     if(swaggerModels === true && allowBlankTargets === undefined) {
         allowBlankTargets = true;
         swaggerModels = undefined;
@@ -116,11 +116,17 @@ function validate(target, swaggerModel, swaggerModels, allowBlankTargets, disall
         return createReturnObject((new Error('Unable to validate an empty value.')));
     }
 
-    if(typeof target !== "object") {
-        return createReturnObject(new Error('Unable to validate a model that is not proper JSON'));
-    }
     if(!swaggerModel) {
         return createReturnObject(new Error('Unable to validate against an undefined model.'));
+    }
+
+    var targetType = typeof target;
+    var modelType = swaggerModel.type || 'object';
+
+    if(targetType !== "object") {
+        if(targetType !== modelType) {
+            return createReturnObject(new Error('Unable to validate a model with an type: ' + targetType + ', expected: ' + modelType));
+        }
     }
 
     var requireFieldErrs;
@@ -132,7 +138,7 @@ function validate(target, swaggerModel, swaggerModels, allowBlankTargets, disall
         }
     }
 
-    var validationErrs = validateSpec(target, swaggerModel, swaggerModels, disallowExtraProperties, customValidators);
+    var validationErrs = validateSpec(name, target, swaggerModel, swaggerModels, disallowExtraProperties, customValidators);
 
     if (validationErrs) {
         return createReturnObject(validationErrs, swaggerModel.id);
@@ -204,33 +210,44 @@ function validateProperties(targetProperties, modelProperties) {
     return errors.length > 0 ? errors : null;
 }
 
-function validateSpec(target, model, models, disallowExtraProperties, customValidators) {
+function validateSpec(name, target, model, models, disallowExtraProperties, customValidators) {
     var properties = model.properties;
     var errors = [];
 
     if(!properties) {
-        return null;
+        if(!model.type) {
+            return null;
+        }
+
+        var singleValueErrors = validateValue(name, model, target, models);
+        if(singleValueErrors) {
+            singleValueErrors.forEach(function (error) {
+                errors.push(error);
+            })
+        }
     }
 
-    if(disallowExtraProperties) {
-        errors = validateProperties(Object.keys(target), properties) || [];
-    }
+    else {
+        if (disallowExtraProperties) {
+            errors = validateProperties(Object.keys(target), properties) || [];
+        }
 
-    for(key in properties) {
-        var field = properties[key];
-        var value = target[key];
+        for (key in properties) {
+            var field = properties[key];
+            var value = target[key];
 
-        if (value !== undefined) {
-            var valueErrors = validateValue(key, field, value, models);
+            if (value !== undefined) {
+                var valueErrors = validateValue(key, field, value, models);
 
-            if(!valueErrors) {
-                valueErrors = validateCustom(model.id, key, value, customValidators);
-            }
+                if (!valueErrors) {
+                    valueErrors = validateCustom(model.id, key, value, customValidators);
+                }
 
-            if (valueErrors) {
-                valueErrors.forEach(function (error) {
-                    errors.push(error);
-                })
+                if (valueErrors) {
+                    valueErrors.forEach(function (error) {
+                        errors.push(error);
+                    })
+                }
             }
         }
     }
@@ -337,7 +354,7 @@ function validateType(name, property, field, models) {
     if(!expectedType) {
         if(models && field.$ref) {
             var fieldRef = field.$ref.replace('#/definitions/', '');
-            return validate(property, models[fieldRef], models);
+            return validate(name, property, models[fieldRef], models);
         } else {
             return null;
         }
@@ -346,7 +363,7 @@ function validateType(name, property, field, models) {
     }
 
     if(expectedType === 'object') {
-        return validate(property, field, models);
+        return validate(name, property, field, models);
     }
 
     if(expectedType === 'array') {
@@ -380,7 +397,7 @@ function validateType(name, property, field, models) {
                 var count = 0;
                 var arrayErrors = [];
                 property.forEach(function(value) {
-                    var errors = validate(value, model, models);
+                    var errors = validate(name, value, model, models);
                     if(errors && !errors.valid) {
                         errors.errors.forEach(function(error) {
                             arrayErrors.push(error);

--- a/package.json
+++ b/package.json
@@ -1,19 +1,25 @@
 {
-    "name": "swagger-model-validator",
-    "version": "2.0.3",
-    "description": "Validate incoming objects against Swagger Models.",
-    "keywords": [ "Swagger", "Validation" ],
-    "licence": "MIT",
-    "author": "Brody Dunn",
-    "bugs": {
-        "url": "https://github.com/atlantishealthcare/swagger-model-validator/issues"
-    },
-    "homepage": "https://github.com/atlantishealthcare/swagger-model-validator",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/atlantishealthcare/swagger-model-validator.git"
-    },
-    "scripts": {
-        "test": "nodeunit tests"
-    }
+  "name": "swagger-model-validator",
+  "version": "2.0.3",
+  "description": "Validate incoming objects against Swagger Models.",
+  "keywords": [
+    "Swagger",
+    "Validation"
+  ],
+  "licence": "MIT",
+  "author": "Brody Dunn",
+  "bugs": {
+    "url": "https://github.com/atlantishealthcare/swagger-model-validator/issues"
+  },
+  "homepage": "https://github.com/atlantishealthcare/swagger-model-validator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlantishealthcare/swagger-model-validator.git"
+  },
+  "scripts": {
+    "test": "nodeunit tests"
+  },
+  "devDependencies": {
+    "nodeunit": "^0.9.1"
+  }
 }

--- a/tests/testRefModels1.js
+++ b/tests/testRefModels1.js
@@ -1,0 +1,118 @@
+/**
+ * Created by bdunn on 10/11/2014.
+ */
+var Validator = require('../lib/modelValidator');
+var validator = new Validator();
+
+module.exports.refTests = {
+    hasStringRefTest: function(test) {
+        var data = {
+            biotype: 'protein_coding',
+            location: {
+                top: 1,
+                left: 1,
+                right: 5,
+                bottom: 5
+            }
+        };
+
+        var models = {
+            dataModel: {
+                required: [ "biotype" ],
+                properties: {
+                    biotype: {
+                        $ref: "biotype"
+                    },
+                    location: {
+                        $ref: "Location"
+                    }
+                }
+            },
+            biotype: {
+                type: "string",
+                enum: [
+                    "protein_coding",
+                    "miRNA"
+                ]
+            },
+            Location: {
+                required: [ "top", "left" ],
+                properties: {
+                    top: {
+                        type: "integer"
+                    },
+                    left: {
+                        type: "integer"
+                    },
+                    right: {
+                        type: "integer"
+                    },
+                    bottom: {
+                        type: "integer"
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(data, models["dataModel"], models);
+
+        test.expect(1);
+        test.ok(errors.valid);
+        test.done();
+    },
+    hasStringInvalidRefTest: function(test) {
+        var data = {
+            biotype: 'FOOBAHR',
+            location: {
+                top: 1,
+                left: 1,
+                right: 5,
+                bottom: 5
+            }
+        };
+
+        var models = {
+            dataModel: {
+                required: [ "biotype" ],
+                properties: {
+                    biotype: {
+                        $ref: "biotype"
+                    },
+                    location: {
+                        $ref: "Location"
+                    }
+                }
+            },
+            biotype: {
+                type: "string",
+                enum: [
+                    "protein_coding",
+                    "miRNA"
+                ]
+            },
+            Location: {
+                required: [ "top", "left" ],
+                properties: {
+                    top: {
+                        type: "integer"
+                    },
+                    left: {
+                        type: "integer"
+                    },
+                    right: {
+                        type: "integer"
+                    },
+                    bottom: {
+                        type: "integer"
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(data, models["dataModel"], models);
+
+        test.expect(1);
+        test.ok(!errors.valid);
+        test.done();
+    }
+};


### PR DESCRIPTION
It's valid to define a type that is a primitive (in my use case, a string with a set of allowed values specified in an enum). This pull request adds support for this during validation, and includes a very simple set of tests.

In order to provide sensible error messages, I modified the signature of the private `validate()` function to include a name parameter. To maintain style with the other validate functions, I put this name param at the beginning of the argument list. This name parameter is not available in the public validate function.