### PR TITLE
Bug validator init

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -6,13 +6,14 @@ exports = Validator;
 module.exports = exports = Validator;
 
 function Validator(swagger) {
-    this.customValidators = {};
+
     if(!(this instanceof Validator)) {
         return new Validator(swagger);
     }
 
     var self = this;
 
+    this.customValidators = {};
     this.swagger = swagger;
     if(swagger) {
         swagger.validateModel = function(modelName, obj, allowBlankTarget, disallowExtraProperties) {

--- a/tests/testAddingCustomValidators.js
+++ b/tests/testAddingCustomValidators.js
@@ -291,5 +291,16 @@ module.exports.validatorTests = {
         test.ok(result.valid);
         test.ok(result.errorCount === 0);
         test.done();
+    },
+    testAnonymousValidator: function(test) {
+        test.expect(1);
+        try {
+          Validator();
+          test.ok(true, "Validator initialized");
+        } catch(e) {
+          test.ok(false, "Validator should initialize without throwing error.");
+        }
+
+        test.done();
     }
 };


### PR DESCRIPTION
Seeing initialization failures with the latest release. Small fix to move `this.customValidators` after instance check.

