### PR TITLE
Add the target to the empty value error message.

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -172,7 +172,7 @@ function validate(name, target, swaggerModel, swaggerModels, allowBlankTargets, 
     if(!target) {
         return createReturnObject(new Error('Unable to validate an undefined value.'));
     } else if(allowBlankTargets !== true && isEmpty(target)) {
-        return createReturnObject((new Error('Unable to validate an empty value.')));
+        return createReturnObject((new Error('Unable to validate an empty value. Value: ' + JSON.stringify(target))));
     }
 
     if(!swaggerModel) {


### PR DESCRIPTION
This make is much easier to find out what went wrong. In the context of my program:
* Before:
```
Error: Unable to validate an empty value.
```
* After:
```
Error: Unable to validate an empty value. Value: {"west":null,"east":null,"north":null,"south":null}
```