### PR TITLE
propagate disallowExtraProperties to reference models

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -450,7 +450,7 @@ function validateType(name, property, field, models, disallowExtraProperties) {
     if(!expectedType) {
         if(models && field.$ref) {
             var fieldRef1 = field.$ref.replace('#/definitions/', '');
-            return validate(name, property, models[fieldRef1], models);
+            return validate(name, property, models[fieldRef1], models, null, disallowExtraProperties);
         } else {
             return null;
         }
@@ -499,7 +499,7 @@ function validateType(name, property, field, models, disallowExtraProperties) {
             if(model) {
                 var arrayErrors2 = [];
                 property.forEach(function(value) {
-                    var errors2 = validate(name, value, model, models);
+                    var errors2 = validate(name, value, model, models, null, disallowExtraProperties);
                     if(errors2 && !errors2.valid) {
                         errors2.errors.forEach(function(error) {
                             arrayErrors2.push(error);

--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -195,7 +195,7 @@ function validate(name, target, swaggerModel, swaggerModels, allowBlankTargets, 
         }
     }
 
-    var validationErrs = validateSpec(name, target, swaggerModel, swaggerModels, disallowExtraProperties, customValidators);
+    var validationErrs = validateSpec(name, target, swaggerModel, swaggerModels, allowBlankTargets, disallowExtraProperties, customValidators);
 
     if (validationErrs) {
         return createReturnObject(validationErrs, swaggerModel.id || name);
@@ -273,7 +273,7 @@ function validateProperties(targetProperties, modelProperties) {
     return errors.length > 0 ? errors : null;
 }
 
-function validateSpec(name, target, model, models, disallowExtraProperties, customValidators) {
+function validateSpec(name, target, model, models, allowBlankTargets, disallowExtraProperties, customValidators) {
     var properties = model.properties;
     var errors = [];
 
@@ -301,7 +301,7 @@ function validateSpec(name, target, model, models, disallowExtraProperties, cust
             var value = target[key];
 
             if (value !== undefined) {
-                var valueErrors = validateValue(key, field, value, models, disallowExtraProperties);
+                var valueErrors = validateValue(key, field, value, models, allowBlankTargets, disallowExtraProperties);
 
                 if (!valueErrors) {
                     valueErrors = validateCustom(model.id || name, key, value, customValidators);
@@ -379,10 +379,10 @@ function validateCustom(modelName, name, value, customValidators) {
     return errors.length > 0 ? errors : null;
 }
 
-function validateValue(key, field, value, models, disallowExtraProperties) {
+function validateValue(key, field, value, models, allowBlankTargets, disallowExtraProperties) {
     var errors = [];
     if(value !== undefined) {
-        var typeErr = validateType(key, value, field, models, disallowExtraProperties);
+        var typeErr = validateType(key, value, field, models, allowBlankTargets, disallowExtraProperties);
         if (typeErr) {
             if (typeErr.valid === undefined) {
                 errors.push(typeErr);
@@ -444,13 +444,13 @@ function validateValue(key, field, value, models, disallowExtraProperties) {
     return errors.length > 0 ? errors : null;
 }
 
-function validateType(name, property, field, models, disallowExtraProperties) {
+function validateType(name, property, field, models, allowBlankTargets, disallowExtraProperties) {
 
     var expectedType = field.type;
     if(!expectedType) {
         if(models && field.$ref) {
             var fieldRef1 = field.$ref.replace('#/definitions/', '');
-            return validate(name, property, models[fieldRef1], models, null, disallowExtraProperties);
+            return validate(name, property, models[fieldRef1], models, allowBlankTargets, disallowExtraProperties);
         } else {
             return null;
         }
@@ -463,7 +463,7 @@ function validateType(name, property, field, models, disallowExtraProperties) {
     // asking any further questions of it.
     if(expectedType === 'object') {
         if(field.properties) {
-            return validate(name, property, field, models, null, disallowExtraProperties);
+            return validate(name, property, field, models, allowBlankTargets, disallowExtraProperties);
         } else {
             return null;
         }
@@ -499,7 +499,7 @@ function validateType(name, property, field, models, disallowExtraProperties) {
             if(model) {
                 var arrayErrors2 = [];
                 property.forEach(function(value) {
-                    var errors2 = validate(name, value, model, models, null, disallowExtraProperties);
+                    var errors2 = validate(name, value, model, models, allowBlankTargets, disallowExtraProperties);
                     if(errors2 && !errors2.valid) {
                         errors2.errors.forEach(function(error) {
                             arrayErrors2.push(error);
@@ -547,9 +547,9 @@ function validateType(name, property, field, models, disallowExtraProperties) {
     }
 
     //if(!format) {
-        return new Error(name + ' (' + wrapNUllProperty(property) + ') is not a type of ' + (format || expectedType));
+        return new Error(name + ' (' + wrapNullProperty(property) + ') is not a type of ' + (format || expectedType));
     //} else {
-    //    return new Error(name + ' (' + wrapNUllProperty(property) + ') is not a type of ' + format)
+    //    return new Error(name + ' (' + wrapNullProperty(property) + ') is not a type of ' + format)
     //}
 }
 
@@ -612,7 +612,7 @@ function isExpectedType(property, expectedType) {
     return typeof property === expectedType;
 }
 
-function wrapNUllProperty(property) {
+function wrapNullProperty(property) {
     if(property === null) {
         return "{null}";
     }

--- a/tests/testBlankTargets.js
+++ b/tests/testBlankTargets.js
@@ -1,0 +1,214 @@
+/**
+ * Created by bdunn on 19/03/2015.
+ */
+var Validator = require('../lib/modelValidator');
+var validator = new Validator();
+
+module.exports.validatorTests = {
+    disallowBlankTargets: function (test) {
+        var data = {};
+
+        var model = {
+            required: [ 'id' ],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === "Unable to validate an empty value.", errors.errors[0].message);
+
+        test.done();
+    },
+    allowBlankTargets: function (test) {
+        var data = {};
+
+        var model = {
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model, null, true);
+
+        test.expect(1);
+        test.ok(errors.valid);
+
+        test.done();
+    },
+    disallowNestedBlankTargets: function (test) {
+        var person = {
+            id: 1,
+            names: {}
+        };
+        var model = {
+            required: ['id'],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                },
+                names: {
+                    type: 'object',
+                    properties: {
+                        firstName: {
+                            type: "string",
+                            description: "First Name"
+                        },
+                        lastName: {
+                            type: "string",
+                            description: "Last Name"
+                        }
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(person, model);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === "Unable to validate an empty value.", errors.errors[0].message);
+
+        test.done();
+    },
+    allowNestedBlankTargets: function (test) {
+        var person = {
+            id: 1,
+            names: {}
+        };
+        var model = {
+            required: ['id'],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                },
+                names: {
+                    type: 'object',
+                    properties: {
+                        firstName: {
+                            type: "string",
+                            description: "First Name"
+                        },
+                        lastName: {
+                            type: "string",
+                            description: "Last Name"
+                        }
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(person, model, null, true);
+
+        test.expect(1);
+        test.ok(errors.valid);
+
+        test.done();
+    },
+    allowReferencedBlankTargets: function (test) {
+        var person = {
+            id: 1,
+            names: {}
+        };
+
+        var namesModel = {
+            type: 'object',
+            properties: {
+                firstName: {
+                    type: "string",
+                    description: "First Name"
+                },
+                lastName: {
+                    type: "string",
+                    description: "Last Name"
+                }
+            }
+        };
+
+        var personModel = {
+            required: ['id'],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                },
+                names: {
+                  "$ref": "#/definitions/names"
+                }
+            }
+        };
+
+        var models = {
+          definitions: {
+              names: namesModel,
+              person: personModel
+          }
+        };
+
+        var errors = validator.validate(person, models.definitions.person, models.definitions, true);
+
+        test.expect(1);
+        test.ok(errors.valid);
+
+        test.done();
+    },
+    disallowReferencedBlankTargets: function (test) {
+        var person = {
+            id: 1,
+            names: {}
+        };
+
+        var namesModel = {
+            type: 'object',
+            properties: {
+                firstName: {
+                    type: "string",
+                    description: "First Name"
+                },
+                lastName: {
+                    type: "string",
+                    description: "Last Name"
+                }
+            }
+        };
+
+        var personModel = {
+            required: ['id'],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                },
+                names: {
+                  "$ref": "#/definitions/names"
+                }
+            }
+        };
+
+        var models = {
+          definitions: {
+              names: namesModel,
+              person: personModel
+          }
+        };
+
+        var errors = validator.validate(person, models.definitions.person, models.definitions, false);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === "Unable to validate an empty value.", errors.errors[0].message);
+
+        test.done();
+    }
+};

--- a/tests/testExtraProperties.js
+++ b/tests/testExtraProperties.js
@@ -89,5 +89,57 @@ module.exports.validatorTests = {
         test.ok(errors.errors[0].message === "Target property 'middleName' is not in the model", errors.errors[0].message);
 
         test.done();
+    },
+    disallowReferencedExtraProperties: function (test) {
+        var person = {
+            id: 1,
+            names: {
+                firstName: "Bob",
+                lastName: "Roberts",
+                middleName: "Shouldn't be here"
+            }
+        };
+
+        var namesModel = {
+            type: 'object',
+            properties: {
+                firstName: {
+                    type: "string",
+                    description: "First Name"
+                },
+                lastName: {
+                    type: "string",
+                    description: "Last Name"
+                }
+            }
+        };
+
+        var personModel = {
+            required: ['id'],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                },
+                names: {
+                  "$ref": "#/definitions/names"
+                }
+            }
+        };
+
+        var models = {
+          definitions: {
+              names: namesModel,
+              person: personModel
+          }
+        };
+
+        var errors = validator.validate(person, models.definitions.person, models.definitions, false, true);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === "Target property 'middleName' is not in the model", errors.errors[0].message);
+
+        test.done();
     }
 };


### PR DESCRIPTION
Fixes #68 and propagates `allowBlankTargets` to children.