### PR TITLE
Fixes #58 support allOf property of Swagger 2.0

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -5,6 +5,8 @@
 exports = Validator;
 module.exports = exports = Validator;
 
+var deepmerge = require('deepmerge');
+
 function Validator(swagger) {
 
     if(!(this instanceof Validator)) {
@@ -161,6 +163,29 @@ function getCustomValidatorsFromModel(model, fieldName) {
     return null;
 }
 
+function deepMergeAllOf(model, models) {
+    var merged = {};
+
+    model.allOf.forEach(function (subModel) {
+        if (subModel.$ref) {
+            var refModel = models[subModel.$ref.replace('#/definitions/', '')];
+
+            if (refModel.allOf) {
+                merged = deepmerge(merged, deepMergeAllOf(refModel, models));
+            } else {
+                merged = deepmerge(merged, refModel);
+            }
+        } else {
+            merged = deepmerge(merged, subModel);
+        }
+    });
+
+    var newModel = deepmerge(model, merged);
+    delete newModel.allOf;
+
+    return newModel;
+}
+
 function validate(name, target, swaggerModel, swaggerModels, allowBlankTargets, disallowExtraProperties, customValidators) {
     if(swaggerModels === true && allowBlankTargets === undefined) {
         allowBlankTargets = true;
@@ -177,6 +202,10 @@ function validate(name, target, swaggerModel, swaggerModels, allowBlankTargets, 
 
     if(!swaggerModel) {
         return createReturnObject(new Error('Unable to validate against an undefined model.'));
+    }
+
+    if (swaggerModel.allOf) {
+        swaggerModel = deepMergeAllOf(swaggerModel, swaggerModels);
     }
 
     var targetType = typeof target;

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
       "deletions": 22,
       "hireable": true
     }
-  ]
+  ],
+  "dependencies": {
+    "deepmerge": "^1.2.0"
+  }
 }

--- a/tests/testAllOfModels.js
+++ b/tests/testAllOfModels.js
@@ -1,0 +1,178 @@
+/**
+ * Created by jjcross on 10/27/16
+ */
+var Validator = require('../lib/modelValidator');
+var validator = new Validator();
+
+module.exports.allOfTests = {
+    hasAllOf: function(test) {
+        var data = {
+            sample: true,
+            location: {
+                right: 1,
+                bottom: 1
+            }
+        };
+
+        var model = {
+            "type": "object",
+            allOf: [{
+                properties: {
+                    sample: {
+                        type: "boolean"
+                    }
+                }
+            }, {
+                properties: {
+                    location: {
+                        right: {
+                            type: "integer"
+                        },
+                        bottom: {
+                            type: "integer"
+                        }
+                    }
+                }
+            }]
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(1);
+        test.ok(errors.valid);
+        test.done();
+    },
+    hasAllOfError: function(test) {
+        var data = {
+            sample: true,
+            location: {
+                right: "Not an integer",
+                bottom: 1
+            }
+        };
+
+        var model = {
+            "type": "object",
+            allOf: [{
+                properties: {
+                    sample: {
+                        type: "boolean"
+                    }
+                }
+            }, {
+                properties: {
+                    location: {
+                        type: "object",
+                        properties: {
+                            right: {
+                            type: "integer"
+                            },
+                            bottom: {
+                                type: "integer"
+                            }
+                        }
+                    }
+                }
+            }]
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errorCount === 1, "Errors: " + errors.errors);
+        test.done();
+    },
+    hasAllOfWithRef: function(test) {
+        var data = {
+            sample: true,
+            location: {
+                right: 1,
+                bottom: 1
+            }
+        };
+
+        var models = {
+            dataModel: {
+                allOf: [{
+                    properties: {
+                        sample: {
+                            type: "boolean"
+                        }
+                    }
+                }, {
+                    $ref: "Location"
+                }]
+            },
+            Location: {
+                required: [ "top", "left" ],
+                properties: {
+                    top: {
+                        type: "integer"
+                    },
+                    left: {
+                        type: "integer"
+                    },
+                    right: {
+                        type: "integer"
+                    },
+                    bottom: {
+                        type: "integer",
+                        maximum: 2
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(data, models["dataModel"], models);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errorCount === 2, "Errors: " + errors.errors);
+        test.done();
+    },
+    hasNestedAllOfWithRef: function(test) {
+        var data = {
+            sample: true,
+            top: "Not an integer",
+            left: 1
+        };
+
+        var models = {
+            dataModel: {
+                type: "object",
+                allOf: [{
+                    properties: {
+                        sample: {
+                            type: "boolean"
+                        }
+                    }
+                }, {
+                    $ref: "Location"
+                }]
+            },
+            Location: {
+                allOf: [{
+                    properties: {
+                        top: {
+                            type: "integer"
+                        }
+                    }
+                }, {
+                    properties: {
+                        left: {
+                            type: "integer"
+                        }
+                    }
+                }]
+            }
+        };
+
+        var errors = validator.validate(data, models["dataModel"], models);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errorCount === 1, "Errors: " + errors.errors);
+        test.done();
+    }
+}


### PR DESCRIPTION
Added support for the allOf property by deep merging the objects in the allOf array, including $refs and the allOf arrays in those $refs.  The deep merged object is then used as the swaggerModel passed into validateSpec.

Because of the deep merge, I added a dependency on the deepmerge library instead of writing a new implementation.

This passes all of the tests currently and I added some of my own, let me know if there is a better way to do this!