### PR TITLE
Allow empty string values valid for type: string

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -166,10 +166,10 @@ function validate(name, target, swaggerModel, swaggerModels, allowBlankTargets, 
         allowBlankTargets = true;
         swaggerModels = undefined;
     } else if(swaggerModels === false || swaggerModels === null) {
-            swaggerModels = undefined;
+        swaggerModels = undefined;
     }
 
-    if(!target) {
+    if(target === undefined || target === null) {
         return createReturnObject(new Error('Unable to validate an undefined value.'));
     } else if(allowBlankTargets !== true && isEmptyObject(target)) {
         return createReturnObject((new Error('Unable to validate an empty value.')));


### PR DESCRIPTION
Seems that without this, it fails to validate empty strings, confusing them with undefined. I would think it would also affect type: number with 0's using this falsey check. Suggesting this change to explicitly check for undefined/null instead of falsey.