### PR TITLE
Return error if integer or number type property receives a string value

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -610,7 +610,9 @@ function isIntegerType(property, format) {
 }
 
 function isNumberType(property, format) {
-    if(!format || format === 'float' || format === 'double') {
+    if(!isExpectedType(property, 'number')) {
+        return false;
+    } else if(!format || format === 'float' || format === 'double') {
         if (!isNaN(parseFloat(property)) && isFinite(property)) {
             return true;
         }

--- a/tests/testIntegerValidation.js
+++ b/tests/testIntegerValidation.js
@@ -27,6 +27,28 @@ module.exports.validationTests = {
 
         test.done();
     },
+    integerAsStringTypeTest: function(test) {
+        var data = {
+            id: '123'
+        };
+        var model = {
+            required: [ 'id' ],
+            properties: {
+                id: {
+                    type: 'integer',
+                    description: 'The object id'
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === 'id (123) is not a type of integer', 'message: ' + errors.errors[0].message);
+
+        test.done();
+    },
     invalidIntegerBlankTest: function(test) {
         var data = {
             id: ""

--- a/tests/testNumberValidation.js
+++ b/tests/testNumberValidation.js
@@ -28,6 +28,28 @@ module.exports.validationTests = {
 
         test.done();
     },
+    numberAsStringTypeTest: function(test) {
+        var data = {
+            id: '123'
+        };
+        var model = {
+            required: [ 'id' ],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === 'id (123) is not a type of number', 'message: ' + errors.errors[0].message);
+
+        test.done();
+    },
     invalidNumberBlankTest: function(test) {
         var data = {
             id: ""


### PR DESCRIPTION
At present, for a property with type `integer or number`, passing a `stringified number` seems to be valid.
We had to parse the input explicitly after the input validation by the library to conform to our API documentation.

With this PR the validate function returns invalid even if a stringified number is passed in for a property of type number or integer.

