### PR TITLE
Fix console.warn in custom validators

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -371,7 +371,7 @@ function validateCustomFromModel(model, name, value) {
                 }
             }
         } catch(e) {
-            console.warn(error);
+            console.warn(e);
         }
     });
 
@@ -399,7 +399,7 @@ function validateCustom(modelName, name, value, customValidators) {
                 }
             }
         } catch(e) {
-            console.warn(error);
+            console.warn(e);
         }
     });
 


### PR DESCRIPTION
This fixes the warning message in the catch block of custom validators.