### PR TITLE
Report the name of a property in undefined error message

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -75,7 +75,7 @@ function validate(name, target, swaggerModel, swaggerModels, allowBlankTargets, 
     }
 
     if(target === undefined || target === null) {
-        return createReturnObject(new Error('Unable to validate an undefined value.'));
+        return createReturnObject(new Error('Unable to validate an undefined value of property: ' + name));
     } else if(allowBlankTargets !== true && isEmptyObject(target)) {
         return createReturnObject((new Error('Unable to validate an empty value.')));
     }


### PR DESCRIPTION
When a property of an object is undefined the current error message is "Unable to validate an undefined value.".  If the object is large and many properties are undefined, the error message just repeats without specifying the property that's undefined.  This change reports the name of the property that's undefined.  For example:
Unable to validate an undefined value of property: quantity