### PR TITLE
Passes allowBlankTargets properly

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -202,7 +202,7 @@ function validateSpecification(name, target, model, models, allowBlankTargets, d
             return null;
         }
 
-        var singleValueErrors = validateValue(name, model, target, models);
+        var singleValueErrors = validateValue(name, model, target, models, allowBlankTargets, disallowExtraProperties);
         if(singleValueErrors) {
             singleValueErrors.forEach(function (error) {
                 errors.push(error);
@@ -279,7 +279,7 @@ function validateValue(key, field, value, models, allowBlankTargets, disallowExt
             }
         }
 
-        var valueErrors = self.valueValidator.validateValue(key, value, field);
+        var valueErrors = self.valueValidator.validateValue(key, value, field, models, allowBlankTargets, disallowExtraProperties);
         if (valueErrors) {
             valueErrors.forEach(function(error) {
                 errors.push(error);


### PR DESCRIPTION
Hi, first of all thanks for the library. But I've discovered what's probably a bug. I am unable to emulate it in a test case but on our live data, this patch works.

It seems that the `allowBlankTargets` isn't passed properly at all times.

---
Our (simplified) test data:

```json
{
  "ratePlans": [
  {
    "name": "Single room - economy",
      "restrictions": {
        "lengthOfStay": {
          "min": 7,
          "max": 20
        }
      },
    },
    {
      "name": "Single room",
      "restrictions": { },
    }
  ]
}
```

Schema excerpt:

```yaml
    RatePlan:
      type: object
      required:
      - name
      properties:
        name:
          type: string
        restrictions:
          type: object
          properties:
            lengthOfStay:
              type: object
              properties:
                min:
                  type: integer
                  default: 1
                max:
                  type: integer
```


And when called like this

```js
const Validator = require('swagger-model-validator');
// The schemas themselves are quite complex, I can create a repro in a separate repository if needed
let validation = (new Validator()).validate(data, schemas[modelName], schemas, true, false);
```

it fails with

```
{ valid: false,
  errorCount: 1,
  errors:
   [ Error: Unable to validate an empty value for property: restrictions
...
```