### PR TITLE
Removing unused 'incrementDateString' method

### DIFF
--- a/lib/valueValidator.js
+++ b/lib/valueValidator.js
@@ -167,12 +167,6 @@ function validatePattern(name, value, pattern) {
 	return new Error(name + ' does not match the pattern ' + pattern);
 }
 
-function incrementDateString(dateString, increment) {
-    var incrementingDate = new Date(dateString);
-    incrementingDate.setMilliseconds(incrementingDate.getMilliseconds() + increment);
-    return incrementingDate.toISOString();
-}
-
 function validateEnums(name, value, enums) {
     if (value === undefined || value === null) {
         return null;


### PR DESCRIPTION
The method `incrementDateString` from `valueValidator.js` is defined but never used. This PR removes the method definition.

All the tests successfully passed after the change: 305 assertions (248ms)